### PR TITLE
2024100100 release code

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -38,8 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.1'
-            moodle-branch: 'master'
+          - php: '8.3'
+            moodle-branch: 'main'
+            database: 'pgsql'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
             database: 'pgsql'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'

--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -87,6 +87,10 @@ class plugininfo extends plugin implements
         global $COURSE, $CFG, $PAGE;
 
         $ltitool = \panoptoblock_lti_utility::get_course_tool($COURSE->id);
+
+        // Remove sensitive info from $config.
+        unset($ltitool->config['password'], $ltitool->config['servicesalt']);
+
         $resourcebase = sha1(
             $PAGE->url->__toString() . '&' . $PAGE->course->sortorder
                 . '&' . $PAGE->course->timecreated

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version = 2024070900;
+$plugin->version = 2024100100;
 
 // Requires this Moodle version - 4.1.0
 $plugin->requires = 2022112800;
@@ -37,8 +37,8 @@ $plugin->supported = [
     // Support from the Moodle 4.1 series.
     401,
 
-    // To the Moodle 4.3 series.
-    403,
+    // To the Moodle 4.4 series.
+    404,
 ];
 
 // This is considered as ready for production sites.


### PR DESCRIPTION
## Description
This is the current release version of the Panopto LTI Button for TinyMCE Plugin.

This version supports (a) Moodle 4.1, 4.2, 4.3, 4.4 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

This plugin requires the Panopto Moodle Block plugin version 2022122000 or higher.

Below is the list of updates from the previous stable release (2024070900).
- Fixed a potential security vulnerability that could disclose secure LTI configuration information.

## Testing
- [x] Manual and automated tests.


